### PR TITLE
chore: enhance deployment script security by removing private key from .env

### DIFF
--- a/shell/deploy.base.sh
+++ b/shell/deploy.base.sh
@@ -10,7 +10,15 @@ source .env
 
 export ETHERSCAN_API_KEY=$BASESCAN_API_KEY
 export RPC_URL=$BASE_RPC_URL
+export ACCOUNT_NAME=$ACCOUNT_NAME 
 
 read -p "Press enter to begin the deployment..."
 
-forge script script/contracts.s.sol:ContractDeploymentScript --rpc-url $RPC_URL --broadcast -vvvv --private-key $PRIVATE_KEY --verify --delay 15
+# Import wallet interactively if not already imported
+cast wallet list | grep -q "$ACCOUNT_NAME" || cast wallet import "$ACCOUNT_NAME" --interactive
+
+# Retrieve wallet address
+SENDER_ADDRESS=$(cast wallet address --account "$ACCOUNT_NAME")
+
+# Deploy
+forge script script/contracts.s.sol:ContractDeploymentScript --rpc-url $RPC_URL --account "$ACCOUNT_NAME" --sender "$SENDER_ADDRESS" --broadcast -vvvv --verify --delay 15


### PR DESCRIPTION
This update makes the deployment script interactive by allowing wallet import directly via the command line, thereby preventing the need to store sensitive keys in the .env file. This improves security and reduces the risk of accidental exposure of private keys.